### PR TITLE
Change get_output_data return type

### DIFF
--- a/src/loader/beacon_api.rs
+++ b/src/loader/beacon_api.rs
@@ -544,8 +544,8 @@ extern "C" fn beacon_output(_type: c_int, data: *mut c_char, len: c_int) {
 
 /// Retrieves the output data from the beacon.
 #[no_mangle]
-pub fn beacon_get_output_data() -> Carrier {
-    return unsafe { OUTPUT.clone() };
+pub fn beacon_get_output_data() -> &'static mut Carrier {
+    return unsafe { &mut OUTPUT };
 }
 
 /// Format and present output to the Beacon operator.

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -130,7 +130,7 @@ impl<'a> Coffee<'a> {
         self.execute_bof(arguments, argument_size, entrypoint_name)?;
 
         // Get the output and print it
-        let mut output_data = beacon_get_output_data();
+        let output_data = beacon_get_output_data();
 
         // Print output data
         if output_data.len() > 0 {


### PR DESCRIPTION
closes #1 

This PR changes the return type of 

```rust
#[no_mangle]
pub fn beacon_get_output_data() ->  Carrier {
    return unsafe {  OUTPUT.clone()  };
}
```

to

```rust
#[no_mangle]
pub fn beacon_get_output_data() -> &'static mut Carrier {
    return unsafe { &mut OUTPUT };
}
``` 

This allows the callee to clear the output of the original Carrier and not the clone's