### PR TITLE
Fix VaList compilation error on newer nightly Rust

### DIFF
--- a/src/loader/beacon_api.rs
+++ b/src/loader/beacon_api.rs
@@ -457,7 +457,7 @@ extern "C" fn beacon_format_append(format: *mut Formatp, text: *const c_char, le
 
 /// Append a formatted string to this object.
 #[no_mangle]
-unsafe extern "C" fn beacon_format_printf(format: *mut Formatp, fmt: *const c_char, args: ...) {
+unsafe extern "C" fn beacon_format_printf(format: *mut Formatp, fmt: *const c_char, mut args: ...) {
     if format.is_null() {
         return;
     }
@@ -603,7 +603,7 @@ pub extern "C" fn beacon_get_output_data() -> &'static mut Carrier {
 
 /// Format and present output to the Beacon operator.
 #[no_mangle]
-unsafe extern "C" fn beacon_printf(_type: c_int, fmt: *mut c_char, args: ...) {
+unsafe extern "C" fn beacon_printf(_type: c_int, fmt: *mut c_char, mut args: ...) {
     // Use a buffer large enough for most format operations
     let mut buffer = vec![0u8; 4096];
 

--- a/src/loader/beacon_api.rs
+++ b/src/loader/beacon_api.rs
@@ -472,7 +472,7 @@ unsafe extern "C" fn beacon_format_printf(format: *mut Formatp, fmt: *const c_ch
         buffer.as_mut_ptr() as *mut c_char,
         buffer.len() - 1, // Leave space for null terminator
         fmt,
-        args,
+        args.as_va_list(),
     );
 
     // Check if the operation was successful
@@ -612,7 +612,7 @@ unsafe extern "C" fn beacon_printf(_type: c_int, fmt: *mut c_char, args: ...) {
         buffer.as_mut_ptr() as *mut c_char,
         buffer.len() - 1,
         fmt,
-        args,
+        args.as_va_list(),
     );
 
     // Check if the operation was successful


### PR DESCRIPTION
## Summary

- On recent nightly Rust toolchains, `coffee-ldr` fails to compile with two `E0308` mismatched type errors in `beacon_api.rs`
- The `c_variadic` feature changed so that variadic `args: ...` parameters are now `VaListImpl` rather than `VaList`, which doesn't match the `_vsnprintf` extern declaration expecting `core::ffi::VaList`
- Fix: call `args.as_va_list()` to convert `VaListImpl` → `VaList`, and add `mut` to the `args` parameter since `as_va_list()` requires a mutable borrow

## Error before fix

```
error[E0308]: mismatched types
   --> src/loader/beacon_api.rs:475:9
    |
475 |         args,
    |         ^^^^ expected `VaList<'_, '_>`, found `VaListImpl<'_>`

error[E0308]: mismatched types
   --> src/loader/beacon_api.rs:615:9
    |
615 |         args,
    |         ^^^^ expected `VaList<'_, '_>`, found `VaListImpl<'_>`
```

## Changes

**`src/loader/beacon_api.rs`:**
- `beacon_format_printf`: `args: ...` → `mut args: ...`, pass `args.as_va_list()` to `_vsnprintf`
- `beacon_printf`: same fix

Two-line change, both in the same file.